### PR TITLE
fix(workaround): make cap-js/hana inserts possible with systemversioning

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const cds = require('@sap/cds')
+// react on bootstrapping events...
+cds.on('served', () => {
+    const { Book } = cds.entities
+    const { elements } = Book
+    const { toTimestamp, fromTimestamp } = elements
+    toTimestamp.value = 'dummmy'
+    fromTimestamp.value = 'dummy'
+
+})

--- a/srv/cat-service.cds
+++ b/srv/cat-service.cds
@@ -2,5 +2,8 @@ using {my.bookshop as my} from '../db/schema';
 
 service CatalogService {
 
-  entity Book as projection on my.Book
+  entity Book as projection on my.Book excluding {
+    fromTimestamp,
+    toTimestamp
+  }
 }


### PR DESCRIPTION
this is a workaround for the issue reported in https://github.com/cap-js/cds-dbs/issues/829